### PR TITLE
fix: update Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ ENV CUDA_HOME /usr/local/cuda-11.6/
 RUN mkdir -p /home/appuser/Grounded-Segment-Anything
 COPY . /home/appuser/Grounded-Segment-Anything/
 
-RUN apt-get update && apt-get install --no-install-recommends wget ffmpeg=7:* \
-    libsm6=2:* libxext6=2:* git=1:* nano=2.* \
-    vim=2:* -y \
-    && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    wget ffmpeg libsm6 libxext6 git nano vim build-essential \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/appuser/Grounded-Segment-Anything
 RUN python -m pip install --no-cache-dir -e segment_anything


### PR DESCRIPTION
## Summary
- fix Dockerfile package installation by removing strict version pins
- include build-essential for compiling dependencies

## Testing
- `docker build -t gsa-test . >/tmp/docker.log && tail -n 20 /tmp/docker.log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9dc0c5fc8333b0a592cf945d93e0