### PR TITLE
Pin dependency versions and cast logits to float

### DIFF
--- a/GroundingDINO/groundingdino/util/inference.py
+++ b/GroundingDINO/groundingdino/util/inference.py
@@ -66,7 +66,9 @@ def predict(
     with torch.no_grad():
         outputs = model(image[None], captions=[caption])
 
-    prediction_logits = outputs["pred_logits"].cpu().sigmoid()[0]  # prediction_logits.shape = (nq, 256)
+    prediction_logits = (
+        outputs["pred_logits"].cpu().float().sigmoid()[0]
+    )  # prediction_logits.shape = (nq, 256)
     prediction_boxes = outputs["pred_boxes"].cpu()[0]  # prediction_boxes.shape = (nq, 4)
 
     mask = prediction_logits.max(dim=1)[0] > box_threshold

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ diffusers
 gradio
 huggingface_hub
 matplotlib
-numpy
+numpy<2
 onnxruntime
 opencv_python
 Pillow
@@ -11,11 +11,12 @@ pycocotools
 PyYAML
 requests
 setuptools
-supervision
+supervision==0.21.0
 termcolor
 timm
-torch
-torchvision
+torch==1.13.1
+torchvision==0.14.1
+torchaudio==0.13.1
 transformers
 yapf
 nltk


### PR DESCRIPTION
## Summary
- avoid half-precision CPU error by casting prediction logits to float before sigmoid
- pin numpy and other library versions to known working releases

## Testing
- `python -m py_compile GroundingDINO/groundingdino/util/inference.py`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_68bfb80e4118833395bad175a5fb11cc