### PR TITLE
Add DINOv3 encoder option for Grounded SAM

### DIFF
--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -145,7 +145,11 @@ if __name__ == "__main__":
         "--grounded_checkpoint", type=str, required=True, help="path to checkpoint file"
     )
     parser.add_argument(
-        "--sam_version", type=str, default="vit_h", required=False, help="SAM ViT version: vit_b / vit_l / vit_h"
+        "--sam_version",
+        type=str,
+        default="vit_h",
+        required=False,
+        help="SAM encoder version: vit_b / vit_l / vit_h / dinov3",
     )
     parser.add_argument(
         "--sam_checkpoint", type=str, required=False, help="path to sam checkpoint file"

--- a/grounded_sam_multi_gpu_demo.py
+++ b/grounded_sam_multi_gpu_demo.py
@@ -181,7 +181,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Grounded-Segment-Anything Demo", add_help=True)
     parser.add_argument("--config", type=str, required=True, help="path to config file")
     parser.add_argument("--grounded_checkpoint", type=str, required=True, help="path to checkpoint file")
-    parser.add_argument("--sam_version", type=str, default="vit_h", required=False, help="SAM ViT version: vit_b / vit_l / vit_h")
+    parser.add_argument(
+        "--sam_version",
+        type=str,
+        default="vit_h",
+        required=False,
+        help="SAM encoder version: vit_b / vit_l / vit_h / dinov3",
+    )
     parser.add_argument("--sam_checkpoint", type=str, required=False, help="path to sam checkpoint file")
     parser.add_argument("--sam_hq_checkpoint", type=str, default=None, help="path to sam-hq checkpoint file")
     parser.add_argument("--use_sam_hq", action="store_true", help="using sam-hq for prediction")

--- a/segment_anything/segment_anything/__init__.py
+++ b/segment_anything/segment_anything/__init__.py
@@ -9,6 +9,7 @@ from .build_sam import (
     build_sam_vit_h,
     build_sam_vit_l,
     build_sam_vit_b,
+    build_sam_dinov3,
     sam_model_registry,
 )
 from .build_sam_hq import (
@@ -16,6 +17,7 @@ from .build_sam_hq import (
     build_sam_hq_vit_h,
     build_sam_hq_vit_l,
     build_sam_hq_vit_b,
+    build_sam_hq_dinov3,
     sam_hq_model_registry,
 )
 from .predictor import SamPredictor

--- a/segment_anything/segment_anything/build_sam.py
+++ b/segment_anything/segment_anything/build_sam.py
@@ -17,6 +17,7 @@ def build_sam_vit_h(checkpoint=None):
         encoder_depth=32,
         encoder_num_heads=16,
         encoder_global_attn_indexes=[7, 15, 23, 31],
+        vit_patch_size=16,
         checkpoint=checkpoint,
     )
 
@@ -30,6 +31,7 @@ def build_sam_vit_l(checkpoint=None):
         encoder_depth=24,
         encoder_num_heads=16,
         encoder_global_attn_indexes=[5, 11, 17, 23],
+        vit_patch_size=16,
         checkpoint=checkpoint,
     )
 
@@ -40,6 +42,19 @@ def build_sam_vit_b(checkpoint=None):
         encoder_depth=12,
         encoder_num_heads=12,
         encoder_global_attn_indexes=[2, 5, 8, 11],
+        vit_patch_size=16,
+        checkpoint=checkpoint,
+    )
+
+
+def build_sam_dinov3(checkpoint=None):
+    """Build a SAM model with a DINOv3 image encoder."""
+    return _build_sam(
+        encoder_embed_dim=1024,
+        encoder_depth=24,
+        encoder_num_heads=16,
+        encoder_global_attn_indexes=[5, 11, 17, 23],
+        vit_patch_size=14,
         checkpoint=checkpoint,
     )
 
@@ -49,6 +64,7 @@ sam_model_registry = {
     "vit_h": build_sam,
     "vit_l": build_sam_vit_l,
     "vit_b": build_sam_vit_b,
+    "dinov3": build_sam_dinov3,
 }
 
 
@@ -57,11 +73,11 @@ def _build_sam(
     encoder_depth,
     encoder_num_heads,
     encoder_global_attn_indexes,
+    vit_patch_size,
     checkpoint=None,
 ):
     prompt_embed_dim = 256
     image_size = 1024
-    vit_patch_size = 16
     image_embedding_size = image_size // vit_patch_size
     sam = Sam(
         image_encoder=ImageEncoderViT(

--- a/segment_anything/segment_anything/build_sam_hq.py
+++ b/segment_anything/segment_anything/build_sam_hq.py
@@ -17,6 +17,7 @@ def build_sam_hq_vit_h(checkpoint=None):
         encoder_depth=32,
         encoder_num_heads=16,
         encoder_global_attn_indexes=[7, 15, 23, 31],
+        vit_patch_size=16,
         checkpoint=checkpoint,
     )
 
@@ -30,6 +31,7 @@ def build_sam_hq_vit_l(checkpoint=None):
         encoder_depth=24,
         encoder_num_heads=16,
         encoder_global_attn_indexes=[5, 11, 17, 23],
+        vit_patch_size=16,
         checkpoint=checkpoint,
     )
 
@@ -40,6 +42,19 @@ def build_sam_hq_vit_b(checkpoint=None):
         encoder_depth=12,
         encoder_num_heads=12,
         encoder_global_attn_indexes=[2, 5, 8, 11],
+        vit_patch_size=16,
+        checkpoint=checkpoint,
+    )
+
+
+def build_sam_hq_dinov3(checkpoint=None):
+    """Build a SAM-HQ model with a DINOv3 encoder."""
+    return _build_sam(
+        encoder_embed_dim=1024,
+        encoder_depth=24,
+        encoder_num_heads=16,
+        encoder_global_attn_indexes=[5, 11, 17, 23],
+        vit_patch_size=14,
         checkpoint=checkpoint,
     )
 
@@ -49,6 +64,7 @@ sam_hq_model_registry = {
     "vit_h": build_sam_hq_vit_h,
     "vit_l": build_sam_hq_vit_l,
     "vit_b": build_sam_hq_vit_b,
+    "dinov3": build_sam_hq_dinov3,
 }
 
 
@@ -57,11 +73,11 @@ def _build_sam(
     encoder_depth,
     encoder_num_heads,
     encoder_global_attn_indexes,
+    vit_patch_size,
     checkpoint=None,
 ):
     prompt_embed_dim = 256
     image_size = 1024
-    vit_patch_size = 16
     image_embedding_size = image_size // vit_patch_size
     sam = Sam(
         image_encoder=ImageEncoderViT(


### PR DESCRIPTION
## Summary
- add `build_sam_dinov3` and `build_sam_hq_dinov3` for using DINOv3 checkpoints
- allow configurable ViT patch size in SAM builders
- expose DINOv3 builder in module exports and CLI help

## Testing
- `python -m py_compile segment_anything/segment_anything/build_sam.py segment_anything/segment_anything/build_sam_hq.py segment_anything/segment_anything/__init__.py grounded_sam_demo.py grounded_sam_multi_gpu_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfe3ac1970833389eb468c9599b47f